### PR TITLE
Add setup script and README examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
 # RepoUtilidades
+
+Este repositorio contiene varias utilidades y ejemplos.
+
+## Video Pipeline
+
+El paquete `video_pipeline` incluye un script para procesar un archivo de video y obtener una transcripción resumida.
+
+El flujo de trabajo que realiza `process_video.py` es el siguiente:
+1. Extrae la pista de audio de un archivo `.mp4` con `moviepy`.
+2. Transcribe el audio utilizando la biblioteca [`whisper`](https://github.com/openai/whisper) especificando el idioma.
+3. Resume la transcripción con un modelo de `transformers`, por ejemplo `google/mt5-small`.
+
+### Uso
+
+```bash
+python video_pipeline/process_video.py ruta/al/video.mp4
+```
+
+Opciones:
+- `--audio PATH` : ubicación para almacenar el archivo de audio intermedio (por defecto `extracted_audio.wav`).
+- `--model NAME` : tamaño del modelo Whisper a usar (por defecto `base`).
+- `--lang COD` : código de idioma ISO 639-1 del audio (por defecto `es`).
+- `--summary-model NAME` : modelo de transformers para resumir (por defecto `google/mt5-small`).
+
+### Ejemplos
+
+Ejecutar el pipeline con las opciones por defecto:
+
+```bash
+python video_pipeline/process_video.py ruta/al/video.mp4
+```
+
+Usar un modelo de Whisper distinto y guardar el audio temporal en `mi_audio.wav`:
+
+```bash
+python video_pipeline/process_video.py ruta/al/video.mp4 --model small --audio mi_audio.wav
+```
+
+### Dependencias
+
+Puede instalar las dependencias ejecutando el script `setup.sh` incluido en el
+repositorio:
+
+```bash
+bash setup.sh
+```
+
+Este script utiliza `pip` para instalar `moviepy`, `openai-whisper`,
+`transformers` y `torch`. Si lo prefiere, puede instalarlos manualmente con:
+
+```bash
+pip install moviepy openai-whisper transformers torch
+```
+
+El script descargará los modelos necesarios la primera vez que se ejecute.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Simple script to install Python dependencies for video_pipeline
+pip install moviepy openai-whisper transformers torch

--- a/video_pipeline/process_video.py
+++ b/video_pipeline/process_video.py
@@ -1,0 +1,49 @@
+import argparse
+from pathlib import Path
+
+from moviepy.editor import VideoFileClip
+import whisper
+from transformers import pipeline
+
+
+def extract_audio(video_path: Path, audio_path: Path) -> Path:
+    """Extract audio from an mp4 file and save it as wav."""
+    clip = VideoFileClip(str(video_path))
+    clip.audio.write_audiofile(str(audio_path))
+    clip.close()
+    return audio_path
+
+
+def transcribe_audio(audio_path: Path, model_name: str = "base", language: str = "es") -> str:
+    """Transcribe audio using Whisper specifying the language."""
+    model = whisper.load_model(model_name)
+    result = model.transcribe(str(audio_path), language=language)
+    return result.get("text", "")
+
+
+def summarize_text(text: str, model_name: str = "google/mt5-small") -> str:
+    """Summarize text using a transformers pipeline."""
+    summarizer = pipeline("summarization", model=model_name)
+    summary = summarizer(text, max_length=150, min_length=40, do_sample=False)
+    return summary[0]["summary_text"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Process video to summarized transcription")
+    parser.add_argument("video", type=Path, help="Path to input .mp4 file")
+    parser.add_argument("--audio", type=Path, default=Path("extracted_audio.wav"), help="Path to temporary audio file")
+    parser.add_argument("--model", type=str, default="base", help="Whisper model size to use")
+    parser.add_argument("--lang", type=str, default="es", help="Idioma del audio (codigo ISO 639-1)")
+    parser.add_argument("--summary-model", type=str, default="google/mt5-small", help="Transformers model for summarization")
+    args = parser.parse_args()
+
+    audio_path = extract_audio(args.video, args.audio)
+    text = transcribe_audio(audio_path, args.model, args.lang)
+    summary = summarize_text(text, args.summary_model)
+
+    print("\nTranscription:\n", text)
+    print("\nSummary:\n", summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `setup.sh` for easier dependency installation
- add sample commands and script usage to README

## Testing
- `python -m py_compile video_pipeline/process_video.py`


------
https://chatgpt.com/codex/tasks/task_e_68446c1834348327900907c995571a1e