### PR TITLE
Add GUI for video summarizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,104 @@
 # RepoUtilidades
+
+Este repositorio contiene varias utilidades y ejemplos.
+
+## Video Pipeline
+
+El paquete `video_pipeline` incluye un script para procesar un archivo de video y obtener una transcripción resumida.
+
+El flujo de trabajo que realiza `process_video.py` es el siguiente:
+1. Extrae la pista de audio de un archivo `.mp4` con `moviepy`.
+2. Transcribe el audio utilizando la biblioteca [`whisper`](https://github.com/openai/whisper) especificando el idioma.
+3. Resume la transcripción con un modelo de `transformers`, por ejemplo `google/mt5-small`.
+
+### Uso
+
+```bash
+python video_pipeline/process_video.py ruta/al/video.mp4
+```
+
+Opciones:
+- `--audio PATH` : ubicación para almacenar el archivo de audio intermedio (por defecto `extracted_audio.wav`).
+- `--model NAME` : tamaño del modelo Whisper a usar (por defecto `base`).
+- `--lang COD` : código de idioma ISO 639-1 del audio (por defecto `es`).
+- `--summary-model NAME` : modelo de transformers para resumir (por defecto `google/mt5-small`).
+- `--output PATH` : archivo para guardar la transcripción y el resumen (opcional).
+
+### Ejemplos
+
+Ejecutar el pipeline con las opciones por defecto:
+
+```bash
+python video_pipeline/process_video.py ruta/al/video.mp4
+```
+
+Usar un modelo de Whisper distinto y guardar el audio temporal en `mi_audio.wav`:
+
+```bash
+python video_pipeline/process_video.py ruta/al/video.mp4 --model small --audio mi_audio.wav
+```
+Guardar la salida en un archivo `resultado.txt`:
+
+```bash
+python video_pipeline/process_video.py ruta/al/video.mp4 --output resultado.txt
+```
+
+### Dependencias
+
+Puede instalar las dependencias ejecutando el script `setup.sh` incluido en el
+repositorio:
+
+```bash
+bash setup.sh
+```
+
+Este script utiliza `pip` para instalar `moviepy`, `openai-whisper`,
+`transformers` y `torch`. Si lo prefiere, puede instalarlos manualmente con:
+
+```bash
+pip install moviepy openai-whisper transformers torch
+```
+
+El script descargará los modelos necesarios la primera vez que se ejecute.
+
+### Pasos para ejecutar
+
+1. Clonar el repositorio en la carpeta que prefiera y entrar en él
+
+   ```bash
+   git clone <URL-del-repositorio>
+   cd RepoUtilidades
+   ```
+
+2. *(Opcional)* Crear y activar un entorno virtual
+
+   ```bash
+   python -m venv env
+   source env/bin/activate  # en Windows use env\Scripts\activate
+   ```
+
+3. Instalar las dependencias
+
+   ```bash
+   bash setup.sh
+   ```
+
+4. Ejecutar el pipeline indicando la ruta del video
+
+   ```bash
+   python video_pipeline/process_video.py ruta/al/video.mp4
+   ```
+
+### Interfaz gráfica
+
+El paquete incluye un script muy sencillo para usar el pipeline con una
+ventana gráfica. Puede ejecutarlo con:
+
+```bash
+python -m video_pipeline.gui
+```
+
+Si tiene instalado `tkinterdnd2` podrá arrastrar el archivo `.mp4` sobre la
+ventana. En caso contrario utilice el botón **Seleccionar archivo**.
+El programa generará los archivos `transcripcion.txt` y `resumen.txt` dentro
+de una carpeta llamada como el video con el sufijo `_resumed`.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Simple script to install Python dependencies for video_pipeline
+pip install moviepy openai-whisper transformers torch tkinterdnd2

--- a/video_pipeline/gui.py
+++ b/video_pipeline/gui.py
@@ -1,0 +1,57 @@
+import sys
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from pathlib import Path
+
+try:
+    from tkinterdnd2 import DND_FILES, TkinterDnD
+    DND_AVAILABLE = True
+except ImportError:
+    DND_AVAILABLE = False
+
+from .process_video import extract_audio, transcribe_audio, summarize_text
+
+
+def process_video_file(path: Path):
+    audio_path = path.with_suffix('.wav')
+    trans_text = transcribe_audio(extract_audio(path, audio_path))
+    summary = summarize_text(trans_text)
+    out_dir = path.with_name(path.stem + '_resumed')
+    out_dir.mkdir(exist_ok=True)
+    transcript_file = out_dir / 'transcripcion.txt'
+    summary_file = out_dir / 'resumen.txt'
+    transcript_file.write_text(trans_text, encoding='utf-8')
+    summary_file.write_text(summary, encoding='utf-8')
+    messagebox.showinfo('Proceso finalizado', f'Archivos guardados en {out_dir}')
+
+
+def on_drop(event):
+    path = event.data
+    if path:
+        process_video_file(Path(path.strip('{}')))
+
+
+def select_file():
+    filename = filedialog.askopenfilename(filetypes=[('MP4 files', '*.mp4')])
+    if filename:
+        process_video_file(Path(filename))
+
+
+def main():
+    if DND_AVAILABLE:
+        root = TkinterDnD.Tk()
+    else:
+        root = tk.Tk()
+    root.title('Video Summarizer')
+    instr = tk.Label(root, text='Arrastra un archivo .mp4 aqui\no usa el boton para seleccionarlo', width=40, height=10, bg='lightgray')
+    instr.pack(padx=10, pady=10, fill='both', expand=True)
+    button = tk.Button(root, text='Seleccionar archivo', command=select_file)
+    button.pack(pady=(0,10))
+    if DND_AVAILABLE:
+        instr.drop_target_register(DND_FILES)
+        instr.dnd_bind('<<Drop>>', on_drop)
+    root.mainloop()
+
+
+if __name__ == '__main__':
+    main()

--- a/video_pipeline/process_video.py
+++ b/video_pipeline/process_video.py
@@ -1,0 +1,53 @@
+import argparse
+from pathlib import Path
+
+from moviepy.editor import VideoFileClip
+import whisper
+from transformers import pipeline
+
+
+def extract_audio(video_path: Path, audio_path: Path) -> Path:
+    """Extract audio from an mp4 file and save it as wav."""
+    clip = VideoFileClip(str(video_path))
+    clip.audio.write_audiofile(str(audio_path))
+    clip.close()
+    return audio_path
+
+
+def transcribe_audio(audio_path: Path, model_name: str = "base", language: str = "es") -> str:
+    """Transcribe audio using Whisper specifying the language."""
+    model = whisper.load_model(model_name)
+    result = model.transcribe(str(audio_path), language=language)
+    return result.get("text", "")
+
+
+def summarize_text(text: str, model_name: str = "google/mt5-small") -> str:
+    """Summarize text using a transformers pipeline."""
+    summarizer = pipeline("summarization", model=model_name)
+    summary = summarizer(text, max_length=150, min_length=40, do_sample=False)
+    return summary[0]["summary_text"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Process video to summarized transcription")
+    parser.add_argument("video", type=Path, help="Path to input .mp4 file")
+    parser.add_argument("--audio", type=Path, default=Path("extracted_audio.wav"), help="Path to temporary audio file")
+    parser.add_argument("--model", type=str, default="base", help="Whisper model size to use")
+    parser.add_argument("--lang", type=str, default="es", help="Idioma del audio (codigo ISO 639-1)")
+    parser.add_argument("--summary-model", type=str, default="google/mt5-small", help="Transformers model for summarization")
+    parser.add_argument("--output", type=Path, help="Archivo de salida para guardar la transcripcion y el resumen")
+    args = parser.parse_args()
+
+    audio_path = extract_audio(args.video, args.audio)
+    text = transcribe_audio(audio_path, args.model, args.lang)
+    summary = summarize_text(text, args.summary_model)
+    if args.output:
+        with args.output.open("w", encoding="utf-8") as f:
+            f.write(text + "\n\n" + summary)
+
+    print("\nTranscription:\n", text)
+    print("\nSummary:\n", summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add new `gui.py` script with basic drag-and-drop interface
- document how to use the GUI
- include `tkinterdnd2` in setup script for drag-and-drop support
- document step-by-step usage

## Testing
- `python -m py_compile video_pipeline/process_video.py video_pipeline/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68446c1834348327900907c995571a1e